### PR TITLE
Fix Streamlit slider IDs and add UI tests

### DIFF
--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -54,12 +54,12 @@ def calculate_velocity(dataframe: pd.DataFrame) -> pd.DataFrame:
     """
     dataframe = dataframe.copy()
     dataframe['Velocity'] = dataframe['Position'].diff() / dataframe['Time (ms)'].diff() * 1000  # Convert to velocity in appropriate units
-    dataframe['Velocity'] = dataframe['Velocity'].fillna(method='ffill')  # Fill NaN values with 0 for the first row
+    dataframe['Velocity'] = dataframe['Velocity'].ffill()  # Fill NaN values with the previous row
     
     # Add the moving average of the velocity
     dataframe['Velocity_MA(5)'] = dataframe['Velocity'].rolling(window=5).mean()
     # Fill NaN values in 'Velocity_MA' with the previous row's value
-    dataframe['Velocity_MA(5)'] = dataframe['Velocity_MA(5)'].fillna(method='ffill')
+    dataframe['Velocity_MA(5)'] = dataframe['Velocity_MA(5)'].ffill()
     return dataframe
 
 def evaluate_sampling_interval(dataframe: pd.DataFrame) -> Tuple[float, float]:
@@ -103,7 +103,14 @@ def display_sampling_interval_analysis(dataframe: pd.DataFrame, record_index: in
     avg_interval, std_interval = evaluate_sampling_interval(dataframe)
     st.write(f"Average Sampling Interval for Record {record_index}: {avg_interval:.4f} ms")
     st.write(f"Standard Deviation of Sampling Interval for Record {record_index}: {std_interval:.4f} ms")
-    nbins = st.slider(f"Select number of bins for sampling interval histogram (Record {record_index}):", min_value=10, max_value=500, value=50, step=5)
+    nbins = st.slider(
+        f"Select number of bins for sampling interval histogram (Record {record_index}):",
+        min_value=10,
+        max_value=500,
+        value=50,
+        step=5,
+        key=f"sampling_bins_{record_index}",
+    )
     fig = plot_sampling_interval(dataframe, nbins=nbins)
     download_figure_png(fig, f"sampling_interval_record_{record_index}.png")
 

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+import pandas as pd
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+class DummyStreamlit(types.SimpleNamespace):
+    def __init__(self):
+        super().__init__()
+        self.slider_calls = []
+
+    def slider(self, *args, **kwargs):
+        self.slider_calls.append(kwargs.get("key"))
+        return kwargs.get("value", 50)
+
+    def header(self, *args, **kwargs):
+        pass
+
+    def write(self, *args, **kwargs):
+        pass
+
+    def plotly_chart(self, *args, **kwargs):
+        pass
+
+    def download_button(self, *args, **kwargs):
+        pass
+
+    def markdown(self, *args, **kwargs):
+        pass
+
+    def dataframe(self, *args, **kwargs):
+        pass
+
+    def selectbox(self, *args, **kwargs):
+        return None
+
+    def multiselect(self, *args, **kwargs):
+        return []
+
+dummy_streamlit = DummyStreamlit()
+sys.modules['streamlit'] = dummy_streamlit
+
+ui = importlib.reload(importlib.import_module("src.ui_components"))
+
+class TestUIComponents(unittest.TestCase):
+    def test_sampling_slider_unique_keys(self):
+        df = pd.DataFrame({
+            "Point": [0, 1, 2],
+            "Position": [0.0, 1.0, 2.0],
+            "Force": [0.1, 0.2, 0.3],
+            "Time (ms)": [0, 100, 200],
+        })
+        df = ui.calculate_velocity(df)
+
+        ui.plot_sampling_interval = lambda *args, **kwargs: None
+        ui.download_figure_png = lambda *args, **kwargs: None
+
+        ui.display_sampling_interval_analysis(df, 1)
+        ui.display_sampling_interval_analysis(df, 2)
+
+        self.assertEqual(dummy_streamlit.slider_calls, ["sampling_bins_1", "sampling_bins_2"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix deprecated `fillna(method="ffill")` warning
- add unique `key` for sampling interval slider
- test that slider keys are unique when multiple records are shown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68739f2fcf408331b42bd973dd150b25