### PR TITLE
Fix unique Streamlit element keys with class-based UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,16 +15,11 @@ if uploaded_files:
         st.subheader(f"Results for {uploaded_file.name}")
         logparser = LogParser(file_content)
         records_dfs = logparser.parse_log()
+        file_ui = ui.LogFileUI(file_index=file_index, filename=uploaded_file.name)
 
         if records_dfs:
             for index, record_df in enumerate(records_dfs, start=1):
-                record_df = ui.calculate_velocity(record_df)
-                ui.display_data_table(record_df, f"Data for Record {index}:")
-                ui.download_dataframe_csv(
-                    record_df, f"{uploaded_file.name}_record{index}.csv"
-                )
-                ui.display_sampling_interval_analysis(record_df, index, file_index=file_index)
-                ui.select_and_plot_curve(record_df, index, file_index=file_index)
+                file_ui.display_record(record_df, index)
         else:
             st.write("No records found under '[Recorded curves]'.")
 

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -17,7 +17,9 @@ def display_data_table(dataframe: pd.DataFrame, title: str) -> None:
     st.dataframe(dataframe)
 
 
-def download_dataframe_csv(dataframe: pd.DataFrame, filename: str) -> None:
+def download_dataframe_csv(
+    dataframe: pd.DataFrame, filename: str, key: str | None = None
+) -> None:
     """Provide a download button to save the dataframe as a CSV file."""
     csv = dataframe.to_csv(index=False).encode("utf-8")
     st.download_button(
@@ -25,10 +27,11 @@ def download_dataframe_csv(dataframe: pd.DataFrame, filename: str) -> None:
         data=csv,
         file_name=filename,
         mime="text/csv",
+        key=key,
     )
 
 
-def download_figure_png(fig, filename: str) -> None:
+def download_figure_png(fig, filename: str, key: str | None = None) -> None:
     """Provide a download button to save a Plotly figure as PNG."""
     try:
         png_bytes = fig.to_image(format="png")
@@ -37,6 +40,7 @@ def download_figure_png(fig, filename: str) -> None:
             data=png_bytes,
             file_name=filename,
             mime="image/png",
+            key=key,
         )
     except Exception as exc:
         st.warning(f"Could not generate image: {exc}")
@@ -202,3 +206,24 @@ def display_footer(app_version: str, company_name: str) -> None:
     </div>
     """
     st.markdown(footer, unsafe_allow_html=True)
+
+
+class LogFileUI:
+    """Encapsulate UI handling for an individual log file."""
+
+    def __init__(self, file_index: int, filename: str) -> None:
+        self.file_index = file_index
+        self.filename = filename
+
+    def display_record(self, dataframe: pd.DataFrame, record_index: int) -> None:
+        dataframe = calculate_velocity(dataframe)
+        display_data_table(dataframe, f"Data for Record {record_index}:")
+        download_dataframe_csv(
+            dataframe,
+            f"{self.filename}_record{record_index}.csv",
+            key=f"csv_{self.file_index}_{record_index}",
+        )
+        display_sampling_interval_analysis(
+            dataframe, record_index, file_index=self.file_index
+        )
+        select_and_plot_curve(dataframe, record_index, file_index=self.file_index)

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -13,6 +13,7 @@ class DummyStreamlit(types.SimpleNamespace):
         self.slider_calls = []
         self.selectbox_calls = []
         self.multiselect_calls = []
+        self.download_button_calls = []
 
 
     def slider(self, *args, **kwargs):
@@ -29,7 +30,7 @@ class DummyStreamlit(types.SimpleNamespace):
         pass
 
     def download_button(self, *args, **kwargs):
-        pass
+        self.download_button_calls.append(kwargs.get("key"))
 
     def markdown(self, *args, **kwargs):
         pass
@@ -83,6 +84,18 @@ class TestUIComponents(unittest.TestCase):
 
         self.assertEqual(self.streamlit.selectbox_calls, ["x_axis_1_1", "x_axis_2_1"])
         self.assertEqual(self.streamlit.multiselect_calls, ["y_axis_1_1", "y_axis_2_1"])
+
+    def test_download_button_unique_keys(self):
+        df = pd.DataFrame({"A": [1]})
+        dummy_fig = types.SimpleNamespace(to_image=lambda format="png": b"img")
+
+        ui.download_dataframe_csv(df, "file.csv", key="csv_1_1")
+        ui.download_dataframe_csv(df, "file.csv", key="csv_2_1")
+        ui.download_figure_png(dummy_fig, "plot.png", key="fig_1_1")
+        ui.download_figure_png(dummy_fig, "plot.png", key="fig_2_1")
+
+        expected = ["csv_1_1", "csv_2_1", "fig_1_1", "fig_2_1"]
+        self.assertEqual(self.streamlit.download_button_calls, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional key parameter to `download_dataframe_csv`/`download_figure_png`
- introduce `LogFileUI` class to encapsulate per-file UI and supply unique IDs
- update app to use `LogFileUI`
- capture download button keys in tests and check for uniqueness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c189bd688331a193c33324945339