### PR TITLE
Add metadata parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ pyproject.toml     # Poetry configuration
 ## Features
 
 - Parse records inside the `[Recorded curves]` section
+- Parse metadata such as part numbers, program names, timestamps and results
 - Compute and visualize sampling intervals and velocity curves
 - Interactive data display in Streamlit using Plotly
 

--- a/app.py
+++ b/app.py
@@ -14,8 +14,10 @@ if uploaded_files:
         file_content = uploaded_file.read().decode("utf-8")
         st.subheader(f"Results for {uploaded_file.name}")
         logparser = LogParser(file_content)
-        records_dfs = logparser.parse_log()
+        metadata, records_dfs = logparser.parse_log()
         file_ui = ui.LogFileUI(file_index=file_index, filename=uploaded_file.name)
+
+        file_ui.display_metadata(metadata)
 
         if records_dfs:
             for index, record_df in enumerate(records_dfs, start=1):

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -40,6 +40,7 @@ pyproject.toml     # Poetry-Konfiguration
 ## Funktionsübersicht
 
 - Parst die Aufzeichnungen im Abschnitt `[Recorded curves]`
+- Liest Metadaten wie Artikelnummer, Programmname, Zeitstempel und Ergebnisse aus
 - Berechnet und zeigt Abtastintervalle sowie Geschwindigkeitskurven an
 - Interaktive Datenanzeige in Streamlit mit Plotly
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -39,5 +39,6 @@ pyproject.toml     # Poetry 配置
 ## 功能简介
 
 - 解析日志中 `[Recorded curves]` 部分的记录
+- 读取零件号、程序名、时间戳及结果等元数据
 - 计算并展示采样间隔及速度曲线
 - 通过 Plotly 在 Streamlit 中交互式显示数据

--- a/src/log_parser.py
+++ b/src/log_parser.py
@@ -1,7 +1,7 @@
 import re
 import logging
 import pandas as pd
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +9,8 @@ class LogParser:
     def __init__(self, file_content: str) -> None:
         self.file_content: str = file_content
 
-    def parse_log(self) -> List[pd.DataFrame]:
+    def parse_log(self) -> Tuple[Dict[str, str], List[pd.DataFrame]]:
+        metadata: Dict[str, str] = {}
         records: List[Dict[str, Any]] = []
         record_section: bool = False
         current_record: Dict[str, Any] = {}
@@ -17,8 +18,10 @@ class LogParser:
         for line in self.file_content.splitlines():
             if "[Recorded curves]" in line:
                 record_section = True
+                continue
             elif "[Variables]" in line:  # End of recorded curves section
                 record_section = False
+                continue
 
             # Extract records within "[Recorded curves]"
             if record_section:
@@ -37,6 +40,22 @@ class LogParser:
                     current_record["points"].append({"Point": point, "Position": position, "Force": force, "Time (ms)": time_ms})
                 else:
                     logger.warning("Invalid line skipped: %s", line)
+            else:
+                key_val = re.match(r"([^;:]+)[;:]\s*(.+)", line)
+                if key_val:
+                    key = key_val.group(1).strip().lower().replace(" ", "_")
+                    value = key_val.group(2).strip()
+                    metadata[key] = value
+                    continue
+
+                result_match = re.match(
+                    r"(window|threshold|envelope).*?:\s*(.+)",
+                    line,
+                    re.IGNORECASE,
+                )
+                if result_match:
+                    result_key = f"{result_match.group(1).lower()}_result"
+                    metadata[result_key] = result_match.group(2).strip()
 
         # Convert records into a list of dataframes
         record_dfs: List[pd.DataFrame] = [pd.DataFrame(record["points"]) for record in records if "points" in record]
@@ -45,7 +64,7 @@ class LogParser:
        
         for df in record_dfs:
             df['Time (ms)'] = df['Time (ms)'] - df['Time (ms)'][0]
-        return record_dfs
+        return metadata, record_dfs
 
 def parse_time(time_str: str) -> int:
     match = re.match(r'T#(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?(\d+)ms', time_str)

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -2,7 +2,7 @@ import streamlit as st
 import plotly.express as px
 import pandas as pd
 import re
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 
 def display_data_table(dataframe: pd.DataFrame, title: str) -> None:
     """
@@ -216,6 +216,14 @@ class LogFileUI:
     def __init__(self, file_index: int, filename: str) -> None:
         self.file_index = file_index
         self.filename = filename
+
+    def display_metadata(self, metadata: Dict[str, str]) -> None:
+        """Display parsed metadata information."""
+        if not metadata:
+            return
+        st.header("Metadata")
+        meta_df = pd.DataFrame(list(metadata.items()), columns=["Key", "Value"])
+        st.table(meta_df)
 
     def display_record(self, dataframe: pd.DataFrame, record_index: int) -> None:
         dataframe = calculate_velocity(dataframe)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,6 +39,8 @@ class TestLogParser(unittest.TestCase):
     def test_parse_log_basic(self):
         log_content = "\n".join(
             [
+                "Program name;TestProg",
+                "Part number;123",
                 "[Recorded curves]",
                 "[Record 1]",
                 "0;0.0;0.1;T#0ms",
@@ -47,13 +49,36 @@ class TestLogParser(unittest.TestCase):
                 "0;2.0;0.3;T#0ms",
                 "1;3.0;0.4;T#100ms",
                 "[Variables]",
+                "Window result:OK",
+                "Threshold result:OK",
             ]
         )
         parser = LogParser(log_content)
-        dfs = parser.parse_log()
+        metadata, dfs = parser.parse_log()
         self.assertEqual(len(dfs), 2)
         self.assertListEqual(dfs[0]["Point"].tolist(), [0, 1])
         self.assertEqual(dfs[0]["Time (ms)"].iloc[-1], 100)
+
+    def test_parse_metadata(self):
+        log_content = "\n".join(
+            [
+                "Program name;MetaProg",
+                "Part number;999",
+                "[Recorded curves]",
+                "[Record 1]",
+                "0;0.0;0.1;T#0ms",
+                "[Variables]",
+                "Window result:PASS",
+                "Envelope result:FAIL",
+            ]
+        )
+        parser = LogParser(log_content)
+        metadata, dfs = parser.parse_log()
+        self.assertEqual(metadata.get("program_name"), "MetaProg")
+        self.assertEqual(metadata.get("part_number"), "999")
+        self.assertEqual(metadata.get("window_result"), "PASS")
+        self.assertEqual(metadata.get("envelope_result"), "FAIL")
+        self.assertEqual(len(dfs), 1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- parse metadata and results in `LogParser`
- expose metadata in Streamlit app
- show metadata in UI
- extend parser tests with metadata examples
- document metadata parsing in README and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f65077dc8331b0467d313730d5ce