### PR TITLE
Refactor metadata display

### DIFF
--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -222,8 +222,8 @@ class LogFileUI:
         if not metadata:
             return
         st.header("Metadata")
-        meta_df = pd.DataFrame(list(metadata.items()), columns=["Key", "Value"])
-        st.table(meta_df)
+        for label, val in metadata.items():
+            st.write(f"**{label}**: {val}")
 
     def display_record(self, dataframe: pd.DataFrame, record_index: int) -> None:
         dataframe = calculate_velocity(dataframe)


### PR DESCRIPTION
## Summary
- adjust `LogFileUI.display_metadata` to return early on empty metadata
- iterate over metadata items and display with `st.write`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740725e6008331a97d90ee7e019acd