### PR TITLE
Add sidebar file selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pyproject.toml     # Poetry configuration
   force, NOK source, MAC Address and Serial number
 - Compute and visualize sampling intervals and velocity curves
 - Interactive data display in Streamlit using Plotly
+- Select uploaded log files from a sidebar for quick access
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -11,27 +11,29 @@ uploaded_files = st.file_uploader(
 
 if uploaded_files:
 
-    tab_labels = [file.name for file in uploaded_files]
-    tabs = st.tabs(tab_labels)
+    file_names = [file.name for file in uploaded_files]
+    selected_name = st.sidebar.selectbox(
+        "Available log files", file_names, key="file_selector"
+    )
+    selected_index = file_names.index(selected_name)
+    uploaded_file = uploaded_files[selected_index]
 
-    for file_index, (uploaded_file, tab) in enumerate(zip(uploaded_files, tabs), start=1):
-        with tab:
-            file_content = uploaded_file.read().decode("utf-8")
-            st.subheader(f"Results for {uploaded_file.name}")
-            logparser = LogParser(file_content)
-            result = logparser.parse_log()
-            if isinstance(result, tuple) and len(result) == 2:
-                metadata, records_dfs = result
-            else:
-                metadata, records_dfs = {}, []
-            file_ui = ui.LogFileUI(file_index=file_index, filename=uploaded_file.name)
-            if hasattr(file_ui, "display_metadata"):
-                file_ui.display_metadata(metadata)
-            if records_dfs:
-                for index, record_df in enumerate(records_dfs, start=1):
-                    file_ui.display_record(record_df, index)
-            else:
-                st.write("No records found under '[Recorded curves]'.")
+    file_content = uploaded_file.read().decode("utf-8")
+    st.subheader(f"Results for {uploaded_file.name}")
+    logparser = LogParser(file_content)
+    result = logparser.parse_log()
+    if isinstance(result, tuple) and len(result) == 2:
+        metadata, records_dfs = result
+    else:
+        metadata, records_dfs = {}, []
+    file_ui = ui.LogFileUI(file_index=selected_index + 1, filename=uploaded_file.name)
+    if hasattr(file_ui, "display_metadata"):
+        file_ui.display_metadata(metadata)
+    if records_dfs:
+        for index, record_df in enumerate(records_dfs, start=1):
+            file_ui.display_record(record_df, index)
+    else:
+        st.write("No records found under '[Recorded curves]'.")
 
 
 ui.display_footer(app_version="0.3",company_name="Festo SE & Co. KG")

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -47,4 +47,5 @@ pyproject.toml     # Poetry-Konfiguration
   force, NOK source, MAC Address und Serial number
 - Berechnet und zeigt Abtastintervalle sowie Geschwindigkeitskurven an
 - Interaktive Datenanzeige in Streamlit mit Plotly
+- Hochgeladene Logdateien k\xF6nnen \xFCber die Seitenleiste ausgew\xE4hlt werden
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -45,3 +45,4 @@ pyproject.toml     # Poetry 配置
   Result、Max. position、Max. force、NOK source、MAC Address、Serial number
 - 计算并展示采样间隔及速度曲线
 - 通过 Plotly 在 Streamlit 中交互式显示数据
+- 可在侧边栏选择上传的日志文件，便于切换查看

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -15,7 +15,9 @@ class DummyStreamlit(types.SimpleNamespace):
         self.multiselect_calls = []
         self.download_button_calls = []
         self.tabs_calls = []
+        self.sidebar_selectbox_calls = []
         self.uploaded_files = []
+        self.sidebar = types.SimpleNamespace(selectbox=self.sidebar_selectbox)
 
 
     def slider(self, *args, **kwargs):
@@ -53,6 +55,10 @@ class DummyStreamlit(types.SimpleNamespace):
     def tabs(self, names):
         self.tabs_calls.append(names)
         return [self.DummyTab() for _ in names]
+
+    def sidebar_selectbox(self, label, options, *args, **kwargs):
+        self.sidebar_selectbox_calls.append(options)
+        return options[0] if options else None
 
     def markdown(self, *args, **kwargs):
         pass
@@ -159,8 +165,8 @@ class TestAppLayout(unittest.TestCase):
         parser_module.LogParser = self.original_logparser
         ui_module.LogFileUI = self.original_logfileui
 
-    def test_tabs_created_for_uploaded_files(self):
-        self.assertEqual(self.streamlit.tabs_calls, [["a.log", "b.log"]])
+    def test_sidebar_selectbox_called_for_uploaded_files(self):
+        self.assertEqual(self.streamlit.sidebar_selectbox_calls, [["a.log", "b.log"]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch log file navigation from tabs to sidebar select box
- adjust tests for the sidebar approach
- mention sidebar navigation in documentation

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687415dc2f848331819f7eb3993dc2e2